### PR TITLE
extract func output below current func

### DIFF
--- a/refactoring/testdata/extractfunc/001-local-variable/main.golden
+++ b/refactoring/testdata/extractfunc/001-local-variable/main.golden
@@ -8,6 +8,7 @@ func main() {
 	printB()
 	fmt.Println("The variable a is:", a)
 }
+
 func printB() {
 	b := 4
 	fmt.Println("The variable b is:", b)

--- a/refactoring/testdata/extractfunc/002-local-var-as-parameter/main.golden
+++ b/refactoring/testdata/extractfunc/002-local-var-as-parameter/main.golden
@@ -9,6 +9,7 @@ func main() {
 	b = printB()
 	fmt.Println("The variable a is:", a, b)
 }
+
 func printB() int {
 	var b int
 	b = 5

--- a/refactoring/testdata/extractfunc/003-function-return-value/main.golden
+++ b/refactoring/testdata/extractfunc/003-function-return-value/main.golden
@@ -8,6 +8,7 @@ func main() {
 	b := 4
 	changeB(a, b)
 }
+
 func changeB(a int, b int) {
 	fmt.Println("Value of a and b", a, b)
 	b = 77

--- a/refactoring/testdata/extractfunc/004-local-two-var-as-parameter/main.golden
+++ b/refactoring/testdata/extractfunc/004-local-two-var-as-parameter/main.golden
@@ -9,6 +9,7 @@ func main() {
 	b = printB(a)
 	fmt.Println("The new value of b is:", b)
 }
+
 func printB(a int) int {
 	var b int
 	b = 5

--- a/refactoring/testdata/extractfunc/005-param-passing-and-return/main.golden
+++ b/refactoring/testdata/extractfunc/005-param-passing-and-return/main.golden
@@ -11,6 +11,7 @@ func main() {
 	z := a + x + c
 	fmt.Println(z)
 }
+
 func Foo(a int, b int) (int, int) {
 	for a <= b {
 		a += b

--- a/refactoring/testdata/extractfunc/006-for_loop_check_01/main.golden
+++ b/refactoring/testdata/extractfunc/006-for_loop_check_01/main.golden
@@ -8,6 +8,7 @@ func main() {
 	Foo(i)
 	fmt.Println("A statement just after for loop.")
 }
+
 func Foo(i int) {
 	for i <= 5 {
 		if i == 3 {

--- a/refactoring/testdata/extractfunc/007-for_loop_check_02/main.golden
+++ b/refactoring/testdata/extractfunc/007-for_loop_check_02/main.golden
@@ -7,6 +7,7 @@ func main() {
 	i := 0
 	Foo(i)
 }
+
 func Foo(i int) {
 	for {
 		if i == 3 {

--- a/refactoring/testdata/extractfunc/008-for_loop_check_03/main.golden
+++ b/refactoring/testdata/extractfunc/008-for_loop_check_03/main.golden
@@ -9,6 +9,7 @@ func main() {
 	i = i + 2
 	fmt.Println("the value 'i' is:", i)
 }
+
 func Foo(i int) int {
 	for {
 		if i == 3 {

--- a/refactoring/testdata/extractfunc/009-SingleEntryCheck/main.golden
+++ b/refactoring/testdata/extractfunc/009-SingleEntryCheck/main.golden
@@ -8,6 +8,7 @@ func main() {
 	Foo(i)
 	fmt.Println("A statement just after for loop.")
 }
+
 func Foo(i int) {
 	for {
 		if i == 3 {

--- a/refactoring/testdata/extractfunc/010-for loop check/main.golden
+++ b/refactoring/testdata/extractfunc/010-for loop check/main.golden
@@ -7,6 +7,7 @@ func main() {
 	fmt.Println("statement inside the main function")
 	Foo()
 }
+
 func Foo() {
 	for i := 0; i <= 8; i++ {
 		fmt.Println("i is ", i)

--- a/refactoring/testdata/extractfunc/012-continue-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/012-continue-statement-check/main.golden
@@ -11,6 +11,7 @@ func main() {
 	}
 	fmt.Println("A statement just after for loop.")
 }
+
 func Foo(i int) {
 	if i == 3 {
 		continue

--- a/refactoring/testdata/extractfunc/013-extract_ifStmt/main.golden
+++ b/refactoring/testdata/extractfunc/013-extract_ifStmt/main.golden
@@ -9,6 +9,7 @@ func main() {
 	foo(i)
 	fmt.Println("end of main function")
 }
+
 func foo(i int) {
 	if i%2 == 0 {
 		fmt.Println("i is even")

--- a/refactoring/testdata/extractfunc/014-goto-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/014-goto-statement-check/main.golden
@@ -7,6 +7,7 @@ func main() {
 	i := 5
 	Foo(i)
 }
+
 func Foo(i int) {
 	for i < 10 {
 		i++

--- a/refactoring/testdata/extractfunc/015_BREAK_LABEL_CHECK_PASS/main.golden
+++ b/refactoring/testdata/extractfunc/015_BREAK_LABEL_CHECK_PASS/main.golden
@@ -8,6 +8,7 @@ func main() {
 	fmt.Println(y)
 	Foo()
 }
+
 func Foo() {
 ABC:
 	for {

--- a/refactoring/testdata/extractfunc/016_CONTINUE_LABEL_CHECK/main.golden
+++ b/refactoring/testdata/extractfunc/016_CONTINUE_LABEL_CHECK/main.golden
@@ -28,6 +28,7 @@ func main() {
 	}
 	printMap(elements)
 }
+
 func printMap(elements map[string]map[string]string) {
 R:
 	for _, row := range elements {

--- a/refactoring/testdata/extractfunc/017_BREAK_INSIDE_EXPRSWITCH/main.golden
+++ b/refactoring/testdata/extractfunc/017_BREAK_INSIDE_EXPRSWITCH/main.golden
@@ -7,6 +7,7 @@ func main() {
 	j := 4
 	Foo(j)
 }
+
 func Foo(j int) {
 	switch j {
 	case 1, 3, 5, 7, 9:

--- a/refactoring/testdata/extractfunc/018_BREAK_INSIDE_TYPESWITCH/main.golden
+++ b/refactoring/testdata/extractfunc/018_BREAK_INSIDE_TYPESWITCH/main.golden
@@ -8,6 +8,7 @@ func main() {
 	x = 77.0
 	Foo(x)
 }
+
 func Foo(x interface{}) {
 	switch i := x.(type) {
 	case int:

--- a/refactoring/testdata/extractfunc/019_BREAK_SELECT_STATMENT/main.golden
+++ b/refactoring/testdata/extractfunc/019_BREAK_SELECT_STATMENT/main.golden
@@ -19,6 +19,7 @@ func main() {
 	}()
 	Foo(c1, c2)
 }
+
 func Foo(c1 chan string, c2 chan string) {
 	for i := 0; i < 2; i++ {
 		select {

--- a/refactoring/testdata/extractfunc/020_BREAKLABEL_INSIDE_SELECT/main.golden
+++ b/refactoring/testdata/extractfunc/020_BREAKLABEL_INSIDE_SELECT/main.golden
@@ -19,6 +19,7 @@ func main() {
 	}()
 	Foo(c1, c2)
 }
+
 func Foo(c1 chan string, c2 chan string) {
 H:
 	for i := 0; i < 2; i++ {

--- a/refactoring/testdata/extractfunc/021_USING_FALLTHROUGH/main.golden
+++ b/refactoring/testdata/extractfunc/021_USING_FALLTHROUGH/main.golden
@@ -7,6 +7,7 @@ func main() {
 	k := 6
 	Foo(k)
 }
+
 func Foo(k int) {
 	switch k {
 	case 4:

--- a/refactoring/testdata/extractfunc/024_EXTRACT_FROM_FUNC/main.golden
+++ b/refactoring/testdata/extractfunc/024_EXTRACT_FROM_FUNC/main.golden
@@ -12,17 +12,18 @@ func f(n int) {
 	fmt.Println("Statement after for loop", n)
 }
 
-func main() {
-	for i := 0; i < 5; i++ {
-		go f(i)
-	}
-	var input string
-	fmt.Scanln(&input)
-}
 func Foo(n int) {
 	for i := 0; i < 5; i++ {
 		fmt.Println(n, ":", i)
 		amt := time.Duration(rand.Intn(250))
 		time.Sleep(time.Millisecond * amt)
 	}
+}
+
+func main() {
+	for i := 0; i < 5; i++ {
+		go f(i)
+	}
+	var input string
+	fmt.Scanln(&input)
 }

--- a/refactoring/testdata/extractfunc/025_GO_ROUTINE_EXTRACT/main.golden
+++ b/refactoring/testdata/extractfunc/025_GO_ROUTINE_EXTRACT/main.golden
@@ -33,6 +33,7 @@ func main() {
 	var input string
 	fmt.Scanln(&input)
 }
+
 func Foo(c chan string) {
 	go pinger(c)
 	go ponger(c)

--- a/refactoring/testdata/extractfunc/029_FORLOOP_RANGE/main.golden
+++ b/refactoring/testdata/extractfunc/029_FORLOOP_RANGE/main.golden
@@ -9,6 +9,7 @@ func main() {
 	total = Foo(total, xs)
 	fmt.Println(total / float64(len(xs)))
 }
+
 func Foo(total float64, xs []float64) float64 {
 	for _, v := range xs {
 		total += v

--- a/refactoring/testdata/extractfunc/030_FOR_LOOP_ONLY/main.golden
+++ b/refactoring/testdata/extractfunc/030_FOR_LOOP_ONLY/main.golden
@@ -6,6 +6,7 @@ import "fmt"
 func main() {
 	Foo()
 }
+
 func Foo() {
 	for i := 0; i < 3; i++ {
 		fmt.Println(i)

--- a/refactoring/testdata/extractfunc/031_GOTO_STMTS/main.golden
+++ b/refactoring/testdata/extractfunc/031_GOTO_STMTS/main.golden
@@ -8,6 +8,7 @@ func main() {
 	Foo(i)
 	fmt.Println("after for loop")
 }
+
 func Foo(i int) {
 ABC:
 	fmt.Println("ABC")

--- a/refactoring/testdata/extractfunc/032-nested-for-loops/main.golden
+++ b/refactoring/testdata/extractfunc/032-nested-for-loops/main.golden
@@ -12,6 +12,7 @@ func main() {
 	}
 	fmt.Println("out of k loop")
 }
+
 func Foo(i int, k int) int {
 	for j := k; j < 5; j++ {
 		fmt.Println("j =", j)

--- a/refactoring/testdata/extractfunc/033-testing_function_return/main.golden
+++ b/refactoring/testdata/extractfunc/033-testing_function_return/main.golden
@@ -10,6 +10,7 @@ func main() {
 	fmt.Println("the new value of b", b)
 	fmt.Println("The variable a is:", a)
 }
+
 func Foo() int {
 	var b int
 	b = 5

--- a/refactoring/testdata/extractfunc/034-goto-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/034-goto-statement-check/main.golden
@@ -8,6 +8,7 @@ func main() {
 	i++
 	Foo(i)
 }
+
 func Foo(i int) {
 	if i == 6 {
 		goto ABC

--- a/refactoring/testdata/extractfunc/035_BREAK_INSIDE_SELECT/main.golden
+++ b/refactoring/testdata/extractfunc/035_BREAK_INSIDE_SELECT/main.golden
@@ -21,6 +21,7 @@ func main() {
 		Foo(c1, c2)
 	}
 }
+
 func Foo(c1 chan string, c2 chan string) {
 	select {
 	case msg1 := <-c1:

--- a/refactoring/testdata/extractfunc/036-passing-struct-as-parameter/main.golden
+++ b/refactoring/testdata/extractfunc/036-passing-struct-as-parameter/main.golden
@@ -13,6 +13,7 @@ func main() {
 	p.x = 5
 	foo(p)
 }
+
 func foo(p Pt) {
 	p.y = 6
 	fmt.Print("New Pt", p)

--- a/refactoring/testdata/extractfunc/037-passing-structure-by-reference/main.golden
+++ b/refactoring/testdata/extractfunc/037-passing-structure-by-reference/main.golden
@@ -13,6 +13,7 @@ func main() {
 	p.x = 5
 	foo(p)
 }
+
 func foo(p *Pt) {
 	p.y = 6
 	fmt.Print("New Pt", p)

--- a/refactoring/testdata/extractfunc/038-passing-returning-struct-by-value/main.golden
+++ b/refactoring/testdata/extractfunc/038-passing-returning-struct-by-value/main.golden
@@ -14,6 +14,7 @@ func main() {
 	p = foo(p)
 	fmt.Println("Printing Modified point after returning", p)
 }
+
 func foo(p Pt) Pt {
 	p.y = 6
 	fmt.Println("New Pt", p)

--- a/refactoring/testdata/extractfunc/039-pass-return-struct-by-reference/main.golden
+++ b/refactoring/testdata/extractfunc/039-pass-return-struct-by-reference/main.golden
@@ -14,6 +14,7 @@ func main() {
 	foo(p)
 	fmt.Println("Printing Modified point after returning", p)
 }
+
 func foo(p *Pt) {
 	p.y = 6
 	fmt.Println("New Pt", p)

--- a/refactoring/testdata/extractfunc/040-pass-return-struct-and-vars-by-value/main.golden
+++ b/refactoring/testdata/extractfunc/040-pass-return-struct-and-vars-by-value/main.golden
@@ -18,6 +18,7 @@ func main() {
 	fmt.Println("Value of n is ", n)
 	fmt.Println("Printing Modified point after returning", p)
 }
+
 func foo(a int, b int, p Pt) (int, int, Pt) {
 	p.y = 6
 	fmt.Println("New Pt", p)

--- a/refactoring/testdata/extractfunc/041-pass-return-struct-and-vars-by-reference/main.golden
+++ b/refactoring/testdata/extractfunc/041-pass-return-struct-and-vars-by-reference/main.golden
@@ -18,6 +18,7 @@ func main() {
 	fmt.Println("Value of n is ", n)
 	fmt.Println("Printing Modified point after returning", p)
 }
+
 func foo(a int, b int, p *Pt) (int, int) {
 	p.y = 6
 	fmt.Println("New Pt", p)

--- a/refactoring/testdata/extractfunc/042-extracting-from-method/main.golden
+++ b/refactoring/testdata/extractfunc/042-extracting-from-method/main.golden
@@ -16,13 +16,14 @@ func (r *Rectangle) Area_by_reference() int {
 	return r.length * r.width
 }
 
+func (r *Rectangle) incrementFunc() {
+	r.length += 2
+	r.width += 4
+}
+
 func main() {
 	r1 := Rectangle{4, 3}
 	fmt.Println("Rectangle is: ", r1)
 	fmt.Println("Rectangle area is r1.Area_by_value(): 		", r1.Area_by_value())
 	fmt.Println("Rectangle area is (&r1).Area_by_reference(): 	", (&r1).Area_by_reference())
-}
-func (r *Rectangle) incrementFunc() {
-	r.length += 2
-	r.width += 4
 }

--- a/refactoring/testdata/extractfunc/043-extracting-from-method/main.golden
+++ b/refactoring/testdata/extractfunc/043-extracting-from-method/main.golden
@@ -21,6 +21,17 @@ func (people AgesByNames) older() string {
 	return n
 }
 
+func (people AgesByNames) foo(a int) string {
+	var n string
+	for key, value := range people {
+		if value > a {
+			a = value
+			n = key
+		}
+	}
+	return n
+}
+
 func main() {
 	s := SliceOfints{1, 2, 3, 4, 5}
 	folks := AgesByNames{
@@ -32,14 +43,4 @@ func main() {
 
 	fmt.Println("The sum of ints in the slice s is: ", s.sum())
 	fmt.Println("The older in the map folks is:", folks.older())
-}
-func (people AgesByNames) foo(a int) string {
-	var n string
-	for key, value := range people {
-		if value > a {
-			a = value
-			n = key
-		}
-	}
-	return n
 }

--- a/refactoring/testdata/extractfunc/046-extract-from-case/main.golden
+++ b/refactoring/testdata/extractfunc/046-extract-from-case/main.golden
@@ -18,6 +18,7 @@ func main() {
 		fmt.Println("Unknown type. Sorry!")
 	}
 }
+
 func Foo(i float64) {
 	if i == 77.0 {
 		a := i + 3

--- a/refactoring/testdata/extractfunc/047-if-with-condition/main.golden
+++ b/refactoring/testdata/extractfunc/047-if-with-condition/main.golden
@@ -9,6 +9,7 @@ func main() {
 	b = foo(a, b)
 	fmt.Println("the new value of b is ", b)
 }
+
 func foo(a int, b int) int {
 	b = b + 2
 	if a == b {

--- a/refactoring/testdata/extractfunc/048-passing-struct-as-param/main.golden
+++ b/refactoring/testdata/extractfunc/048-passing-struct-as-param/main.golden
@@ -14,6 +14,7 @@ func main() {
 	p = foo(p)
 	fmt.Print("New Pt", p)
 }
+
 func foo(p Pt) Pt {
 	fmt.Println("The value of x is ", p.x)
 	p.y = 6

--- a/refactoring/testdata/extractfunc/049-passing-and-returning-structs/main.golden
+++ b/refactoring/testdata/extractfunc/049-passing-and-returning-structs/main.golden
@@ -14,6 +14,7 @@ func main() {
 	p = foo(p)
 	fmt.Print("New Pt", p)
 }
+
 func foo(p Pt) Pt {
 	fmt.Println("This is testing")
 	p.y = 6

--- a/refactoring/testdata/extractfunc/050-struct-variables-live-test/main.golden
+++ b/refactoring/testdata/extractfunc/050-struct-variables-live-test/main.golden
@@ -13,6 +13,7 @@ func main() {
 	p.x = 22
 	Foo(p)
 }
+
 func Foo(p Pt) {
 	fmt.Println("Here starts the extraction")
 	p.y = 66

--- a/refactoring/testdata/extractfunc/051-Extracting-with-indexVars/main.golden
+++ b/refactoring/testdata/extractfunc/051-Extracting-with-indexVars/main.golden
@@ -17,6 +17,7 @@ func main() {
 	}
 	fmt.Println("2d: ", twoD)
 }
+
 func innerLoop(i int, innerLen int, twoD [][]int) {
 	twoD[i] = make([]int, innerLen)
 	for j := 0; j < innerLen; j++ {

--- a/refactoring/testdata/extractfunc/052-test-vardecl/main.golden
+++ b/refactoring/testdata/extractfunc/052-test-vardecl/main.golden
@@ -9,6 +9,7 @@ func main() {
 	b, c = foo()
 	fmt.Println("IN MAIN", b, c)
 }
+
 func foo() (int, int) {
 	var b int
 	var c int

--- a/refactoring/testdata/extractfunc/053-test-typeswitch-extract/main.golden
+++ b/refactoring/testdata/extractfunc/053-test-typeswitch-extract/main.golden
@@ -8,6 +8,7 @@ func main() {
 	x = 77.0
 	newFunc(x)
 }
+
 func newFunc(x interface{}) {
 	switch x.(type) {
 	case int:

--- a/refactoring/testdata/extractfunc/054-switch-extract/main.golden
+++ b/refactoring/testdata/extractfunc/054-switch-extract/main.golden
@@ -8,6 +8,7 @@ func main() {
 	s2 := "efgh"
 	newFunc(s1, s2)
 }
+
 func newFunc(s1 string, s2 string) {
 	switch s1 {
 	case s2:

--- a/refactoring/testdata/extractfunc/055-switch-extract/main.golden
+++ b/refactoring/testdata/extractfunc/055-switch-extract/main.golden
@@ -7,6 +7,7 @@ func main() {
 	x := 1
 	newFunc(x)
 }
+
 func newFunc(x int) {
 d:
 	for {

--- a/refactoring/testdata/extractfunc/056-select-statement-extract/main.golden
+++ b/refactoring/testdata/extractfunc/056-select-statement-extract/main.golden
@@ -26,6 +26,7 @@ func main() {
 		newFunc(c1, c2, c3)
 	}
 }
+
 func newFunc(c1 <-chan string, c2 <-chan string, c3 <-chan string) {
 	select {
 	case msg := <-c1:

--- a/refactoring/testdata/extractfunc/057-select-statement-extract/main.golden
+++ b/refactoring/testdata/extractfunc/057-select-statement-extract/main.golden
@@ -26,6 +26,7 @@ func main() {
 		fmt.Println("no activity")
 	}
 }
+
 func newFunc(messages chan string) {
 	select {
 	case msg := <-messages:

--- a/refactoring/testdata/extractfunc/058-for-loop-extraction-initStatements-test/main.golden
+++ b/refactoring/testdata/extractfunc/058-for-loop-extraction-initStatements-test/main.golden
@@ -8,6 +8,7 @@ func main() {
 		newFunction(i)
 	}
 }
+
 func newFunction(i int) {
 	if num := 9; num < 10 {
 		A := num

--- a/refactoring/testdata/extractfunc/059-extracting_pointer_expressions/main.golden
+++ b/refactoring/testdata/extractfunc/059-extracting_pointer_expressions/main.golden
@@ -10,6 +10,7 @@ func main() {
 	Square(y)
 	fmt.Println("square(x)", *y)
 }
+
 func Square(y *float64) {
 	*y = *y * *y
 }

--- a/refactoring/testdata/extractfunc/060-test001/main.golden
+++ b/refactoring/testdata/extractfunc/060-test001/main.golden
@@ -14,6 +14,7 @@ func main() {
 	}
 	fmt.Println("the new value of b is ", b)
 }
+
 func foo(b int) int {
 	fmt.Println("a and b are equal")
 	b = b + 1

--- a/refactoring/testdata/extractfunc/061-test002-checkstart positionlate/main.golden
+++ b/refactoring/testdata/extractfunc/061-test002-checkstart positionlate/main.golden
@@ -9,6 +9,7 @@ func main() {
 	b, c = foo()
 	fmt.Println("IN MAIN", b, c)
 }
+
 func foo() (int, int) {
 	var b int
 	var c int

--- a/refactoring/testdata/extractfunc/062-test003/main.golden
+++ b/refactoring/testdata/extractfunc/062-test003/main.golden
@@ -31,6 +31,7 @@ func main() {
 		fmt.Println("no activity")
 	}
 }
+
 func newFunc(msg string) {
 	fmt.Println("sent message", msg)
 }

--- a/refactoring/testdata/extractfunc/064-test005/main.golden
+++ b/refactoring/testdata/extractfunc/064-test005/main.golden
@@ -12,6 +12,7 @@ func main() {
 	res := foo()
 	fmt.Println("1+2 =", res)
 }
+
 func foo() int {
 	res := plus(1, 2)
 	return res

--- a/refactoring/testdata/extractfunc/070-test011/main.golden
+++ b/refactoring/testdata/extractfunc/070-test011/main.golden
@@ -8,6 +8,7 @@ func main() {
 	FOO(i)
 	fmt.Println("after loop")
 }
+
 func FOO(i int) {
 	for i <= 5 {
 		if i == 3 {

--- a/refactoring/testdata/extractfunc/071-test012/main.golden
+++ b/refactoring/testdata/extractfunc/071-test012/main.golden
@@ -8,6 +8,7 @@ func main() {
 	FOO(i)
 	fmt.Println("after loop")
 }
+
 func FOO(i int) {
 	for i <= 5 {
 		if i == 3 {

--- a/refactoring/testdata/extractfunc/073-test014/main.golden
+++ b/refactoring/testdata/extractfunc/073-test014/main.golden
@@ -8,6 +8,7 @@ func main() {
 	b := printB()
 	fmt.Println("The variable a is:", a, b)
 }
+
 func printB() int {
 	b := 4
 	fmt.Println("The variable b is:", b)

--- a/refactoring/testdata/extractfunc/074-test015/main.golden
+++ b/refactoring/testdata/extractfunc/074-test015/main.golden
@@ -15,6 +15,12 @@ func main() {
 
 }
 
+func FOO(v float64) {
+	if temp, ok := tripleNum(v); ok {
+		fmt.Println("##temp", temp)
+	}
+}
+
 func doubleXS(xs []float64) []float64 {
 	var temp []float64
 	for i, _ := range xs {
@@ -25,9 +31,4 @@ func doubleXS(xs []float64) []float64 {
 
 func tripleNum(num float64) (float64, bool) {
 	return num * 3, true
-}
-func FOO(v float64) {
-	if temp, ok := tripleNum(v); ok {
-		fmt.Println("##temp", temp)
-	}
 }

--- a/refactoring/testdata/extractfunc/076-struct-assign-member/main.golden
+++ b/refactoring/testdata/extractfunc/076-struct-assign-member/main.golden
@@ -9,6 +9,7 @@ func main() {
 	s = extracted(s) //<<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }
+
 func extracted(s struct{ member int }) struct{ member int } {
 	s.member = 3
 	return s

--- a/refactoring/testdata/extractfunc/077-structptr-assign-member/main.golden
+++ b/refactoring/testdata/extractfunc/077-structptr-assign-member/main.golden
@@ -9,6 +9,7 @@ func main() {
 	extracted(s) //<<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }
+
 func extracted(s *struct{ member int }) {
 	s.member = 3
 }

--- a/refactoring/testdata/extractfunc/078-structptr-assign-ptr/main.golden
+++ b/refactoring/testdata/extractfunc/078-structptr-assign-ptr/main.golden
@@ -9,6 +9,7 @@ func main() {
 	s = extracted() //<<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }
+
 func extracted() *struct{ member int } {
 	var s *struct{ member int }
 	s = &struct{ member int }{4}


### PR DESCRIPTION
this just kind of bugged me, I believe someone else expressed a similar
sentiment that the extracted func should be output below the current enclosed
func rather than at the bottom of the file. this does that. also added an
extra newline preceding the extracted function. this tends to be programmer
preference for whether to put associated functions above or below their caller
(or, for that matter, anywhere remotely close) -- it's rather pedantic to
bicker over, I could put it above if someone so prefers that to be the
default; we could also easily make it configurable.

updated the tests by hand to make sure I didn't fuck anything up. should check
out

p.s. I had a go at fixing the issues with anonymous function extraction. seems the error bubbles up from the ast package, may look further into this soon as it's a pretty big 'gotcha' and seems like our analyses our robust enough to cover it currently.
