### PR TITLE
Bug/godoc adds comment when existing

### DIFF
--- a/refactoring/godoc.go
+++ b/refactoring/godoc.go
@@ -249,4 +249,12 @@ type Rectangle struct {
       </td>
     </tr>
   </table>
+
+  <h4>Limitations</h4>
+  <ul>
+    <li>When a single declaration contains non-exported declarations
+        followed by exported declarations (e.g.,
+        <tt>var x, Y int</tt>), a documentation comment will not be
+        added.</li>
+  </ul>
 `

--- a/refactoring/godoc.go
+++ b/refactoring/godoc.go
@@ -95,8 +95,6 @@ func (r *AddGoDoc) addComments() {
 				r.addComment(decl, decl.Name.Name) //, 1)
 			}
 		case *ast.GenDecl: // type and value declarations
-			// we want to try and be consistent with user commenting style,
-			// so we want to detect if they're commenting individual specs for groups or not.
 			switch decl.Tok {
 			case token.IMPORT:
 				continue
@@ -116,10 +114,12 @@ func (r *AddGoDoc) addComment(decl ast.Node, comment string) {
 }
 
 // addCommentToGenDecl adds doc comments to a GenDecl (var, type, or const).
+//
 // A GenDecl can have a doc comment of its own, or if it contains several
 // declarations, each one can have its own doc comment.  If the user has
-// already commented at least one individual declaration, we comment the rest;
-// if not, we add a comment for the GenDecl as a whole.
+// already commented at least one individual declaration, we comment the rest
+// to be consistent with their style; if not, we add a comment for the GenDecl
+// as a whole, to avoid being too obtrusive.
 func (r *AddGoDoc) addCommentToGenDecl(decl *ast.GenDecl) {
 	if decl.Doc != nil {
 		return

--- a/refactoring/testdata/godoc/002-existing-comment/main.go
+++ b/refactoring/testdata/godoc/002-existing-comment/main.go
@@ -1,0 +1,12 @@
+package main // <<<<< godoc,1,1,1,1,pass
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}
+
+// Shape is a struct
+type Shape struct {
+	Name string
+}

--- a/refactoring/testdata/godoc/002-existing-comment/main.go
+++ b/refactoring/testdata/godoc/002-existing-comment/main.go
@@ -6,7 +6,30 @@ func main() {
 	fmt.Println("hello")
 }
 
+// MyInt is mine
+type MyInt int
+
+// MyInterface is my interface
+type MyInterface interface {
+	SumSides() int
+}
+
 // Shape is a struct
 type Shape struct {
-	Name string
+	NumSides int
+	Sides    []int
+}
+
+// SumSides adds all of the sides together
+func (s *Shape) SumSides() int {
+	var sum int
+	for _, side := range s.Sides {
+		sum += side
+	}
+	return sum
+}
+
+// Hello says hello
+func Hello(name string) {
+	fmt.Printf("Hello, %s\n", name)
 }

--- a/refactoring/testdata/godoc/002-existing-comment/main.golden
+++ b/refactoring/testdata/godoc/002-existing-comment/main.golden
@@ -1,0 +1,12 @@
+package main // <<<<< godoc,1,1,1,1,pass
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}
+
+// Shape is a struct
+type Shape struct {
+	Name string
+}

--- a/refactoring/testdata/godoc/002-existing-comment/main.golden
+++ b/refactoring/testdata/godoc/002-existing-comment/main.golden
@@ -6,7 +6,30 @@ func main() {
 	fmt.Println("hello")
 }
 
+// MyInt is mine
+type MyInt int
+
+// MyInterface is my interface
+type MyInterface interface {
+	SumSides() int
+}
+
 // Shape is a struct
 type Shape struct {
-	Name string
+	NumSides int
+	Sides    []int
+}
+
+// SumSides adds all of the sides together
+func (s *Shape) SumSides() int {
+	var sum int
+	for _, side := range s.Sides {
+		sum += side
+	}
+	return sum
+}
+
+// Hello says hello
+func Hello(name string) {
+	fmt.Printf("Hello, %s\n", name)
 }

--- a/refactoring/testdata/godoc/012-multiple-types/main.golden
+++ b/refactoring/testdata/godoc/012-multiple-types/main.golden
@@ -1,13 +1,11 @@
 package main // <<<<< godoc,1,1,1,1,pass
 
+//  TODO: NEEDS COMMENT INFO
 type (
 	a int
-	// B TODO: NEEDS COMMENT INFO
 	B int
 	c int
-	// D TODO: NEEDS COMMENT INFO
 	D int
-	// E TODO: NEEDS COMMENT INFO
 	E struct{}
 )
 

--- a/refactoring/testdata/godoc/013-multiple-same-line/main.golden
+++ b/refactoring/testdata/godoc/013-multiple-same-line/main.golden
@@ -1,13 +1,11 @@
 package main // <<<<< godoc,1,1,1,1,pass
 
+//  TODO: NEEDS COMMENT INFO
 type (
 	a int
-	// B TODO: NEEDS COMMENT INFO
 	B int
 	c int
-	// D TODO: NEEDS COMMENT INFO
 	D int
-	// E TODO: NEEDS COMMENT INFO
 	E struct{}
 )
 

--- a/refactoring/testdata/godoc/014-consistent-comment-style/main.go
+++ b/refactoring/testdata/godoc/014-consistent-comment-style/main.go
@@ -1,0 +1,22 @@
+package main // <<<<< godoc,1,1,1,1,pass
+
+type (
+	// A is a type
+	A int
+	B int
+	c string
+)
+
+const (
+	StatusOk = 1
+	// StatusBad is bad
+	StatusBad = 2
+)
+
+var (
+	Foo = "Foo"
+	Bar = "Bar"
+)
+
+func main() {
+}

--- a/refactoring/testdata/godoc/014-consistent-comment-style/main.golden
+++ b/refactoring/testdata/godoc/014-consistent-comment-style/main.golden
@@ -1,0 +1,25 @@
+package main // <<<<< godoc,1,1,1,1,pass
+
+type (
+	// A is a type
+	A int
+	// B TODO: NEEDS COMMENT INFO
+	B int
+	c string
+)
+
+const (
+	// StatusOk TODO: NEEDS COMMENT INFO
+	StatusOk = 1
+	// StatusBad is bad
+	StatusBad = 2
+)
+
+//  TODO: NEEDS COMMENT INFO
+var (
+	Foo = "Foo"
+	Bar = "Bar"
+)
+
+func main() {
+}

--- a/refactoring/testdata/godoc/015-multiple-same-line-noparen/main.go
+++ b/refactoring/testdata/godoc/015-multiple-same-line-noparen/main.go
@@ -1,0 +1,8 @@
+package main // <<<<< godoc,1,1,1,1,pass
+
+var a, B, c, D int
+
+// Known limitation - no comment added
+
+func main() {
+}

--- a/refactoring/testdata/godoc/015-multiple-same-line-noparen/main.golden
+++ b/refactoring/testdata/godoc/015-multiple-same-line-noparen/main.golden
@@ -1,0 +1,8 @@
+package main // <<<<< godoc,1,1,1,1,pass
+
+var a, B, c, D int
+
+// Known limitation - no comment added
+
+func main() {
+}


### PR DESCRIPTION
This fixes #37.

We also weren't supporting exported variables and constants, so that's been added. Also, this tries to detect existing comments for group declarations and tries to be consistent. Ex: if the user has comments for individual declarations within a group, we stay consistent with that vs just adding a comment to the top of the group. If there are no comments, we just add a comment for the group to be less obtrusive.

Ex:
```go
const (
    // A is a constant
    A = 1
    B = 2
)
```
turns into
```go
const (
    // A is a constant
    A = 1
    // B TODO: NEEDS COMMENT INFO
    B = 2
)
```

But if none exist, then:
```go
// TODO: NEEDS COMMENT INFO
const (
    A = 1
    B = 2
)
``` 
I'm not a fan of the code. I don't like the way there is repetitive code for variables and type declarations, but I couldn't think of a better way to deal with the two different types (`ast.ValueSpec` & `ast.TypeSpec`). Would love some comments on better ways to do this.