### PR TITLE
Fix renaming functions

### DIFF
--- a/refactoring/testdata/rename/072-funcdecl-rename/main.go
+++ b/refactoring/testdata/rename/072-funcdecl-rename/main.go
@@ -1,0 +1,4 @@
+package main
+
+func mail() { // <<<<<rename,3,6,3,10,main,pass
+}

--- a/refactoring/testdata/rename/072-funcdecl-rename/main.golden
+++ b/refactoring/testdata/rename/072-funcdecl-rename/main.golden
@@ -1,0 +1,4 @@
+package main
+
+func main() { // <<<<<rename,3,6,3,10,main,pass
+}


### PR DESCRIPTION
In my case, godoctor fails to rename functions. I don't know if this is a general problem with the current codebase, or if it's rather specific to my input file.

Happens to me with this input file: https://github.com/infinimesh/mqtt-go/blob/master/cmd/example_server/main.go 

`[/home/j0e/gopath/bin/godoctor -w -file /home/j0e/gopath/src/github.com/infinimesh/mqtt-go/cmd/example_server/main.go -pos 943,4 rename main2]
Defaulting to package scope github.com/infinimesh/mqtt-go/cmd/example_server for refactoring (provide an explicit scope to change this)
../cmd/example_server/main.go:28:7: Error: Please select an identifier to rename. (Selected node: *ast.FuncDecl)
`
Pos and len are correct as far as i saw (pos on first char of func name, and len is correct)

I'm aware that renaming the main will fail with a different error as godoctor won't allow renaming the main func, but let's ignore that :)

in some cases, SelectedNode is set to ast.FuncDecl instead of ast.Ident, even if
the -pos flag was given correctly. In many cases, it's not a problem as the
Ident is part of the struct (e.g. for FuncDecl)

My fix just accepts the fact that rename gets passed a FuncDecl instead of the Ident. It's fine, since FuncDecl hat a member "Name" which is the Ident.
It feels like this is not the perfect solution. Most likely, the "processing" before rename - where the "SelectedNode" is determined, should be modified. However, as i'm not very deep into godoctor's codebase this was the most reasonable fix to apply for me. Especially since such a change might affect other modules beside rename.

I'm very open to help if this approach is not correct (let me wait for test results :) ), as i'm not very much into godoctor's codebase.