### PR TITLE
Add missing error handlers to tests

### DIFF
--- a/analysis/dataflow/dataflow_test.go
+++ b/analysis/dataflow/dataflow_test.go
@@ -541,7 +541,7 @@ func BenchmarkMain(b *testing.B) {
 	config.Dir = "../../"
 	// config.CreateFromFilenames("main", "../../main.go")
 
-	prog, err := loader.Load(&config)
+	prog, err := loader.Load(&config, func(err error) { b.Fatal(err.Error()) })
 	if err != nil {
 		b.Error(err.Error())
 		b.FailNow()
@@ -596,7 +596,7 @@ func getWrapper(t mocker, str string) *CFGWrapper {
 	config.Dir = dir
 	config.Overlay = map[string][]byte{filepath.Join(dir, "/main.go"): []byte(str)}
 
-	prog, err := loader.Load(&config)
+	prog, err := loader.Load(&config, func(err error) { t.Fatal(err.Error()) })
 	if err != nil {
 		t.Fatal(err.Error())
 		return nil

--- a/analysis/dataflow/example_test.go
+++ b/analysis/dataflow/example_test.go
@@ -35,8 +35,13 @@ func ExampleDefsReaching() {
 	config.Dir = "testdata"
 	config.Overlay = map[string][]byte{"main.go": []byte(src)}
 
-	prog, err := loader.Load(&config)
+	var laterError error
+
+	prog, err := loader.Load(&config, func(err error) { laterError = err })
 	if err != nil {
+		return
+	}
+	if laterError != nil {
 		return
 	}
 
@@ -82,8 +87,13 @@ func ExampleLiveVars() {
 	config.Dir = "testdata"
 	config.Overlay = map[string][]byte{"main.go": []byte(src)}
 
-	prog, err := loader.Load(&config)
+	var laterError error
+
+	prog, err := loader.Load(&config, func(err error) { laterError = err })
 	if err != nil {
+		return
+	}
+	if laterError != nil {
 		return
 	}
 

--- a/analysis/names/names_test.go
+++ b/analysis/names/names_test.go
@@ -25,7 +25,7 @@ import (
 func setup(t *testing.T) *loader.Program {
 	var lconfig packages.Config
 	lconfig.Dir = filepath.Join("testdata/src/foo")
-	prog, err := loader.Load(&lconfig)
+	prog, err := loader.Load(&lconfig, func(err error) { t.Fatal(err.Error()) })
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Not sure if this is exactly how it should work, but it fixes the compilation of tests at least.