### PR TITLE
Normalize paths in TestFindOccurrences

### DIFF
--- a/analysis/names/names_test.go
+++ b/analysis/names/names_test.go
@@ -186,6 +186,10 @@ func check(actual, expect []string, t *testing.T) {
 	if err != nil {
 		t.Fatal("couldn't get wd")
 	}
+	wd, err = filepath.EvalSymlinks(wd)
+	if err != nil {
+		t.Fatalf("couldn't evaluate symlinks on %q: %q", wd, err)
+	}
 	for i := range expect {
 		expect[i] = filepath.Join(wd, expect[i])
 	}


### PR DESCRIPTION
If `godoctor` is a in a directory that at some point is a symlink, then something in `golang.org/x/tools/go/packages.Load` normalizes the returned paths, so when generating the expected list, do the same thing.