### PR TITLE
Fix tests 1 20

### DIFF
--- a/analysis/dataflow/testdata/main.go
+++ b/analysis/dataflow/testdata/main.go
@@ -1,7 +1,5 @@
 package main
 
-import "fmt"
-
 func main() {
 	// this file is overridden in tests but has to exist due to quirk in package loading
 }

--- a/refactoring/testdata/debug/showast/main.go.debugOutput
+++ b/refactoring/testdata/debug/showast/main.go.debugOutput
@@ -7,20 +7,22 @@
      6  .  .  Obj: nil
      7  .  }
      8  .  Decls: nil
-     9  .  Scope: *ast.Scope {
-    10  .  .  Outer: nil
-    11  .  .  Objects: map[string]*ast.Object (len = 0) {}
-    12  .  }
-    13  .  Imports: nil
-    14  .  Unresolved: nil
-    15  .  Comments: []*ast.CommentGroup (len = 1) {
-    16  .  .  0: *ast.CommentGroup {
-    17  .  .  .  List: []*ast.Comment (len = 1) {
-    18  .  .  .  .  0: *ast.Comment {
-    19  .  .  .  .  .  Slash: ./testdata/debug/showast/main.go:1:14
-    20  .  .  .  .  .  Text: "//<<<<<debug,1,1,1,1,showast,pass"
-    21  .  .  .  .  }
-    22  .  .  .  }
-    23  .  .  }
-    24  .  }
-    25  }
+     9  .  FileStart: ./testdata/debug/showast/main.go:1:1
+    10  .  FileEnd: ./testdata/debug/showast/main.go:1:48
+    11  .  Scope: *ast.Scope {
+    12  .  .  Outer: nil
+    13  .  .  Objects: map[string]*ast.Object (len = 0) {}
+    14  .  }
+    15  .  Imports: nil
+    16  .  Unresolved: nil
+    17  .  Comments: []*ast.CommentGroup (len = 1) {
+    18  .  .  0: *ast.CommentGroup {
+    19  .  .  .  List: []*ast.Comment (len = 1) {
+    20  .  .  .  .  0: *ast.Comment {
+    21  .  .  .  .  .  Slash: ./testdata/debug/showast/main.go:1:14
+    22  .  .  .  .  .  Text: "//<<<<<debug,1,1,1,1,showast,pass"
+    23  .  .  .  .  }
+    24  .  .  .  }
+    25  .  .  }
+    26  .  }
+    27  }

--- a/refactoring/testdata/extractfunc/001-local-variable/main.go
+++ b/refactoring/testdata/extractfunc/001-local-variable/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,8,2,9,37,printB,pass
+// <<<<<extract,8,2,9,37,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/001-local-variable/main.golden
+++ b/refactoring/testdata/extractfunc/001-local-variable/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,8,2,9,37,printB,pass
+// <<<<<extract,8,2,9,37,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/002-local-var-as-parameter/main.go
+++ b/refactoring/testdata/extractfunc/002-local-var-as-parameter/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,10,37,printB,pass
+// <<<<<extract,9,2,10,37,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/002-local-var-as-parameter/main.golden
+++ b/refactoring/testdata/extractfunc/002-local-var-as-parameter/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,10,37,printB,pass
+// <<<<<extract,9,2,10,37,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/003-function-return-value/main.go
+++ b/refactoring/testdata/extractfunc/003-function-return-value/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,38,changeB,pass
+// <<<<<extract,9,2,11,38,changeB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/003-function-return-value/main.golden
+++ b/refactoring/testdata/extractfunc/003-function-return-value/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,38,changeB,pass
+// <<<<<extract,9,2,11,38,changeB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/004-local-two-var-as-parameter/main.go
+++ b/refactoring/testdata/extractfunc/004-local-two-var-as-parameter/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,10,46,printB,pass
+// <<<<<extract,9,2,10,46,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/004-local-two-var-as-parameter/main.golden
+++ b/refactoring/testdata/extractfunc/004-local-two-var-as-parameter/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,10,46,printB,pass
+// <<<<<extract,9,2,10,46,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/005-param-passing-and-return/main.go
+++ b/refactoring/testdata/extractfunc/005-param-passing-and-return/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,10,2,14,15,Foo,pass
+// <<<<<extract,10,2,14,15,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/005-param-passing-and-return/main.golden
+++ b/refactoring/testdata/extractfunc/005-param-passing-and-return/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,10,2,14,15,Foo,pass
+// <<<<<extract,10,2,14,15,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/006-for_loop_check_01/main.go
+++ b/refactoring/testdata/extractfunc/006-for_loop_check_01/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/006-for_loop_check_01/main.golden
+++ b/refactoring/testdata/extractfunc/006-for_loop_check_01/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/007-for_loop_check_02/main.go
+++ b/refactoring/testdata/extractfunc/007-for_loop_check_02/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/007-for_loop_check_02/main.golden
+++ b/refactoring/testdata/extractfunc/007-for_loop_check_02/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/008-for_loop_check_03/main.go
+++ b/refactoring/testdata/extractfunc/008-for_loop_check_03/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/008-for_loop_check_03/main.golden
+++ b/refactoring/testdata/extractfunc/008-for_loop_check_03/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/009-SingleEntryCheck/main.go
+++ b/refactoring/testdata/extractfunc/009-SingleEntryCheck/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/009-SingleEntryCheck/main.golden
+++ b/refactoring/testdata/extractfunc/009-SingleEntryCheck/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,Foo,pass
+// <<<<<extract,8,2,14,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/010-for-loop-check/main.go
+++ b/refactoring/testdata/extractfunc/010-for-loop-check/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,16,59,Foo,pass
+// <<<<<extract,8,2,16,59,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/010-for-loop-check/main.golden
+++ b/refactoring/testdata/extractfunc/010-for-loop-check/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,16,59,Foo,pass
+// <<<<<extract,8,2,16,59,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/011-break-statement-check/main.go
+++ b/refactoring/testdata/extractfunc/011-break-statement-check/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,3,12,34,Foo,fail
+// <<<<<extract,9,3,12,34,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/011-break-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/011-break-statement-check/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,12,34,Foo,fail
+// <<<<<extract,9,2,12,34,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/012-continue-statement-check/main.go
+++ b/refactoring/testdata/extractfunc/012-continue-statement-check/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,3,12,34,Foo,fail
+// <<<<<extract,9,3,12,34,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/012-continue-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/012-continue-statement-check/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,12,34,Foo,fail
+// <<<<<extract,9,2,12,34,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/013-extract_ifStmt/main.go
+++ b/refactoring/testdata/extractfunc/013-extract_ifStmt/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,2,foo,pass
+// <<<<<extract,9,2,11,2,foo,pass
 
 package main
 

--- a/refactoring/testdata/extractfunc/013-extract_ifStmt/main.golden
+++ b/refactoring/testdata/extractfunc/013-extract_ifStmt/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,2,foo,pass
+// <<<<<extract,9,2,11,2,foo,pass
 
 package main
 

--- a/refactoring/testdata/extractfunc/014-goto-statement-check/main.go
+++ b/refactoring/testdata/extractfunc/014-goto-statement-check/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,24,25,Foo,pass
+// <<<<<extract,8,2,24,25,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/014-goto-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/014-goto-statement-check/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,24,25,Foo,pass
+// <<<<<extract,8,2,24,25,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/015_BREAK_LABEL_CHECK_PASS/main.go
+++ b/refactoring/testdata/extractfunc/015_BREAK_LABEL_CHECK_PASS/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,1,21,2,Foo,pass
+// <<<<<extract,9,1,21,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/015_BREAK_LABEL_CHECK_PASS/main.golden
+++ b/refactoring/testdata/extractfunc/015_BREAK_LABEL_CHECK_PASS/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,1,21,2,Foo,pass
+// <<<<<extract,9,1,21,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/016_CONTINUE_LABEL_CHECK/main.go
+++ b/refactoring/testdata/extractfunc/016_CONTINUE_LABEL_CHECK/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,29,1,37,2,printMap,pass
+// <<<<<extract,29,1,37,2,printMap,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/016_CONTINUE_LABEL_CHECK/main.golden
+++ b/refactoring/testdata/extractfunc/016_CONTINUE_LABEL_CHECK/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,29,1,37,2,printMap,pass
+// <<<<<extract,29,1,37,2,printMap,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/017_BREAK_INSIDE_EXPRSWITCH/main.go
+++ b/refactoring/testdata/extractfunc/017_BREAK_INSIDE_EXPRSWITCH/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,20,2,Foo,pass
+// <<<<<extract,8,2,20,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/017_BREAK_INSIDE_EXPRSWITCH/main.golden
+++ b/refactoring/testdata/extractfunc/017_BREAK_INSIDE_EXPRSWITCH/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,20,2,Foo,pass
+// <<<<<extract,8,2,20,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/018_BREAK_INSIDE_TYPESWITCH/main.go
+++ b/refactoring/testdata/extractfunc/018_BREAK_INSIDE_TYPESWITCH/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,21,2,Foo,pass
+// <<<<<extract,9,2,21,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/018_BREAK_INSIDE_TYPESWITCH/main.golden
+++ b/refactoring/testdata/extractfunc/018_BREAK_INSIDE_TYPESWITCH/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,21,2,Foo,pass
+// <<<<<extract,9,2,21,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/019_BREAK_SELECT_STATMENT/main.go
+++ b/refactoring/testdata/extractfunc/019_BREAK_SELECT_STATMENT/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,30,2,Foo,pass
+// <<<<<extract,20,2,30,2,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/019_BREAK_SELECT_STATMENT/main.golden
+++ b/refactoring/testdata/extractfunc/019_BREAK_SELECT_STATMENT/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,30,2,Foo,pass
+// <<<<<extract,20,2,30,2,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/020_BREAKLABEL_INSIDE_SELECT/main.go
+++ b/refactoring/testdata/extractfunc/020_BREAKLABEL_INSIDE_SELECT/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,20,1,31,2,Foo,pass
+// <<<<<extract,20,1,31,2,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/020_BREAKLABEL_INSIDE_SELECT/main.golden
+++ b/refactoring/testdata/extractfunc/020_BREAKLABEL_INSIDE_SELECT/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,20,1,31,2,Foo,pass
+// <<<<<extract,20,1,31,2,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/021_USING_FALLTHROUGH/main.go
+++ b/refactoring/testdata/extractfunc/021_USING_FALLTHROUGH/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,26,2,Foo,pass
+// <<<<<extract,8,2,26,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/021_USING_FALLTHROUGH/main.golden
+++ b/refactoring/testdata/extractfunc/021_USING_FALLTHROUGH/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,26,2,Foo,pass
+// <<<<<extract,8,2,26,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/022_USING_MULTIVAL_RETURN/main.go
+++ b/refactoring/testdata/extractfunc/022_USING_MULTIVAL_RETURN/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,11,2,13,2,Foo,fail
+// <<<<<extract,11,2,13,2,Foo,fail
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/022_USING_MULTIVAL_RETURN/main.golden
+++ b/refactoring/testdata/extractfunc/022_USING_MULTIVAL_RETURN/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,11,1,13,1,Foo,fail
+// <<<<<extract,11,1,13,1,Foo,fail
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/023_RETURN_FAIL/main.go
+++ b/refactoring/testdata/extractfunc/023_RETURN_FAIL/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,13,3,16,3,Foo,fail
+// <<<<<extract,13,3,16,3,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/023_RETURN_FAIL/main.golden
+++ b/refactoring/testdata/extractfunc/023_RETURN_FAIL/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,13,3,16,3,Foo,fail
+// <<<<<extract,13,3,16,3,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/024_EXTRACT_FROM_FUNC/main.go
+++ b/refactoring/testdata/extractfunc/024_EXTRACT_FROM_FUNC/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,11,2,15,2,Foo,pass
+// <<<<<extract,11,2,15,2,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/024_EXTRACT_FROM_FUNC/main.golden
+++ b/refactoring/testdata/extractfunc/024_EXTRACT_FROM_FUNC/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,11,2,15,2,Foo,pass
+// <<<<<extract,11,2,15,2,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/025_GO_ROUTINE_EXTRACT/main.go
+++ b/refactoring/testdata/extractfunc/025_GO_ROUTINE_EXTRACT/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,31,2,32,13,Foo,pass
+// <<<<<extract,31,2,32,13,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/025_GO_ROUTINE_EXTRACT/main.golden
+++ b/refactoring/testdata/extractfunc/025_GO_ROUTINE_EXTRACT/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,31,2,32,13,Foo,pass
+// <<<<<extract,31,2,32,13,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/026_DEFER_FUNC/main.go
+++ b/refactoring/testdata/extractfunc/026_DEFER_FUNC/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,13,25,Foo,fail
+// <<<<<extract,12,2,13,25,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/026_DEFER_FUNC/main.golden
+++ b/refactoring/testdata/extractfunc/026_DEFER_FUNC/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,13,25,Foo,fail
+// <<<<<extract,12,2,13,25,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/027_DEFER_FUNC_1/main.go
+++ b/refactoring/testdata/extractfunc/027_DEFER_FUNC_1/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,7,2,9,2,Foo,fail
+// <<<<<extract,7,2,9,2,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/027_DEFER_FUNC_1/main.golden
+++ b/refactoring/testdata/extractfunc/027_DEFER_FUNC_1/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,7,2,9,2,Foo,fail
+// <<<<<extract,7,2,9,2,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/028_DEFER_FUNC_2/main.go
+++ b/refactoring/testdata/extractfunc/028_DEFER_FUNC_2/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,12,23,Foo,fail
+// <<<<<extract,12,2,12,23,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/028_DEFER_FUNC_2/main.golden
+++ b/refactoring/testdata/extractfunc/028_DEFER_FUNC_2/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,12,23,Foo,fail
+// <<<<<extract,12,2,12,23,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/029_FORLOOP_RANGE/main.go
+++ b/refactoring/testdata/extractfunc/029_FORLOOP_RANGE/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,11,2,Foo,pass
+// <<<<<extract,9,2,11,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/029_FORLOOP_RANGE/main.golden
+++ b/refactoring/testdata/extractfunc/029_FORLOOP_RANGE/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,11,2,Foo,pass
+// <<<<<extract,9,2,11,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/030_FOR_LOOP_ONLY/main.go
+++ b/refactoring/testdata/extractfunc/030_FOR_LOOP_ONLY/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,7,2,9,2,Foo,pass
+// <<<<<extract,7,2,9,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/030_FOR_LOOP_ONLY/main.golden
+++ b/refactoring/testdata/extractfunc/030_FOR_LOOP_ONLY/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,7,2,9,2,Foo,pass
+// <<<<<extract,7,2,9,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/031_GOTO_STMTS/main.go
+++ b/refactoring/testdata/extractfunc/031_GOTO_STMTS/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,1,17,2,Foo,pass
+// <<<<<extract,8,1,17,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/031_GOTO_STMTS/main.golden
+++ b/refactoring/testdata/extractfunc/031_GOTO_STMTS/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,1,17,2,Foo,pass
+// <<<<<extract,8,1,17,2,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/032-nested-for-loops/main.go
+++ b/refactoring/testdata/extractfunc/032-nested-for-loops/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,10,3,20,3,Foo,pass
+// <<<<<extract,10,3,20,3,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/032-nested-for-loops/main.golden
+++ b/refactoring/testdata/extractfunc/032-nested-for-loops/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,10,3,20,3,Foo,pass
+// <<<<<extract,10,3,20,3,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/033-testing_function_return/main.go
+++ b/refactoring/testdata/extractfunc/033-testing_function_return/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,11,6,Foo,pass
+// <<<<<extract,9,2,11,6,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/033-testing_function_return/main.golden
+++ b/refactoring/testdata/extractfunc/033-testing_function_return/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,11,6,Foo,pass
+// <<<<<extract,9,2,11,6,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/034-goto-statement-check/main.go
+++ b/refactoring/testdata/extractfunc/034-goto-statement-check/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,17,35,Foo,pass
+// <<<<<extract,9,2,17,35,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/034-goto-statement-check/main.golden
+++ b/refactoring/testdata/extractfunc/034-goto-statement-check/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,17,35,Foo,pass
+// <<<<<extract,9,2,17,35,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/035_BREAK_INSIDE_SELECT/main.go
+++ b/refactoring/testdata/extractfunc/035_BREAK_INSIDE_SELECT/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,21,3,29,3,Foo,pass
+// <<<<<extract,21,3,29,3,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/035_BREAK_INSIDE_SELECT/main.golden
+++ b/refactoring/testdata/extractfunc/035_BREAK_INSIDE_SELECT/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,21,3,29,3,Foo,pass
+// <<<<<extract,21,3,29,3,Foo,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/036-passing-struct-as-parameter/main.go
+++ b/refactoring/testdata/extractfunc/036-passing-struct-as-parameter/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,23,foo,pass
+// <<<<<extract,14,2,15,23,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/036-passing-struct-as-parameter/main.golden
+++ b/refactoring/testdata/extractfunc/036-passing-struct-as-parameter/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,23,foo,pass
+// <<<<<extract,14,2,15,23,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/037-passing-structure-by-reference/main.go
+++ b/refactoring/testdata/extractfunc/037-passing-structure-by-reference/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,23,foo,pass
+// <<<<<extract,14,2,15,23,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/037-passing-structure-by-reference/main.golden
+++ b/refactoring/testdata/extractfunc/037-passing-structure-by-reference/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,23,foo,pass
+// <<<<<extract,14,2,15,23,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/038-passing-returning-struct-by-value/main.go
+++ b/refactoring/testdata/extractfunc/038-passing-returning-struct-by-value/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,25,foo,pass
+// <<<<<extract,14,2,15,25,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/038-passing-returning-struct-by-value/main.golden
+++ b/refactoring/testdata/extractfunc/038-passing-returning-struct-by-value/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,25,foo,pass
+// <<<<<extract,14,2,15,25,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/039-pass-return-struct-by-reference/main.go
+++ b/refactoring/testdata/extractfunc/039-pass-return-struct-by-reference/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,25,foo,pass
+// <<<<<extract,14,2,15,25,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/039-pass-return-struct-by-reference/main.golden
+++ b/refactoring/testdata/extractfunc/039-pass-return-struct-by-reference/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,25,foo,pass
+// <<<<<extract,14,2,15,25,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/040-pass-return-struct-and-vars-by-value/main.go
+++ b/refactoring/testdata/extractfunc/040-pass-return-struct-and-vars-by-value/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,16,2,19,15,foo,pass
+// <<<<<extract,16,2,19,15,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/040-pass-return-struct-and-vars-by-value/main.golden
+++ b/refactoring/testdata/extractfunc/040-pass-return-struct-and-vars-by-value/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,16,2,19,15,foo,pass
+// <<<<<extract,16,2,19,15,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/041-pass-return-struct-and-vars-by-reference/main.go
+++ b/refactoring/testdata/extractfunc/041-pass-return-struct-and-vars-by-reference/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,16,2,19,15,foo,pass
+// <<<<<extract,16,2,19,15,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/041-pass-return-struct-and-vars-by-reference/main.golden
+++ b/refactoring/testdata/extractfunc/041-pass-return-struct-and-vars-by-reference/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,16,2,19,15,foo,pass
+// <<<<<extract,16,2,19,15,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/042-extracting-from-method/main.go
+++ b/refactoring/testdata/extractfunc/042-extracting-from-method/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,15,2,16,13,incrementFunc,pass
+// <<<<<extract,15,2,16,13,incrementFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/042-extracting-from-method/main.golden
+++ b/refactoring/testdata/extractfunc/042-extracting-from-method/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,15,2,16,13,incrementFunc,pass
+// <<<<<extract,15,2,16,13,incrementFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/043-extracting-from-method/main.go
+++ b/refactoring/testdata/extractfunc/043-extracting-from-method/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,25,2,foo,pass
+// <<<<<extract,20,2,25,2,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/043-extracting-from-method/main.golden
+++ b/refactoring/testdata/extractfunc/043-extracting-from-method/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,25,2,foo,pass
+// <<<<<extract,20,2,25,2,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/044-extract-from-anonymous-function/main.go
+++ b/refactoring/testdata/extractfunc/044-extract-from-anonymous-function/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,10,3,11,42,increment,fail
+// <<<<<extract,10,3,11,42,increment,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/044-extract-from-anonymous-function/main.golden
+++ b/refactoring/testdata/extractfunc/044-extract-from-anonymous-function/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,10,3,11,42,increment,fail
+// <<<<<extract,10,3,11,42,increment,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/045-extract-from-type-switch-statement/main.go
+++ b/refactoring/testdata/extractfunc/045-extract-from-type-switch-statement/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,28,4,31,4,foo,fail
+// <<<<<extract,28,4,31,4,foo,fail
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/045-extract-from-type-switch-statement/main.golden
+++ b/refactoring/testdata/extractfunc/045-extract-from-type-switch-statement/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,28,4,31,4,foo,fail
+// <<<<<extract,28,4,31,4,foo,fail
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/046-extract-from-case/main.go
+++ b/refactoring/testdata/extractfunc/046-extract-from-case/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,3,17,3,Foo,pass
+// <<<<<extract,14,3,17,3,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/046-extract-from-case/main.golden
+++ b/refactoring/testdata/extractfunc/046-extract-from-case/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,3,17,3,Foo,pass
+// <<<<<extract,14,3,17,3,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/047-if-with-condition/main.go
+++ b/refactoring/testdata/extractfunc/047-if-with-condition/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,15,2,foo,pass
+// <<<<<extract,9,2,15,2,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/047-if-with-condition/main.golden
+++ b/refactoring/testdata/extractfunc/047-if-with-condition/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,15,2,foo,pass
+// <<<<<extract,9,2,15,2,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/048-passing-struct-as-param/main.go
+++ b/refactoring/testdata/extractfunc/048-passing-struct-as-param/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,8,foo,pass
+// <<<<<extract,14,2,15,8,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/048-passing-struct-as-param/main.golden
+++ b/refactoring/testdata/extractfunc/048-passing-struct-as-param/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,8,foo,pass
+// <<<<<extract,14,2,15,8,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/049-passing-and-returning-structs/main.go
+++ b/refactoring/testdata/extractfunc/049-passing-and-returning-structs/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,8,foo,pass
+// <<<<<extract,14,2,15,8,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/049-passing-and-returning-structs/main.golden
+++ b/refactoring/testdata/extractfunc/049-passing-and-returning-structs/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,14,2,15,8,foo,pass
+// <<<<<extract,14,2,15,8,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/050-struct-variables-live-test/main.go
+++ b/refactoring/testdata/extractfunc/050-struct-variables-live-test/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,14,2,16,25,Foo,pass
+// <<<<<extract,14,2,16,25,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/050-struct-variables-live-test/main.golden
+++ b/refactoring/testdata/extractfunc/050-struct-variables-live-test/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,14,2,16,25,Foo,pass
+// <<<<<extract,14,2,16,25,Foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/051-Extracting-with-indexVars/main.go
+++ b/refactoring/testdata/extractfunc/051-Extracting-with-indexVars/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,16,3,19,3,innerLoop,pass
+// <<<<<extract,16,3,19,3,innerLoop,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/051-Extracting-with-indexVars/main.golden
+++ b/refactoring/testdata/extractfunc/051-Extracting-with-indexVars/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,16,3,19,3,innerLoop,pass
+// <<<<<extract,16,3,19,3,innerLoop,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/052-test-vardecl/main.go
+++ b/refactoring/testdata/extractfunc/052-test-vardecl/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,11,32,foo,pass
+// <<<<<extract,9,2,11,32,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/052-test-vardecl/main.golden
+++ b/refactoring/testdata/extractfunc/052-test-vardecl/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,2,11,32,foo,pass
+// <<<<<extract,9,2,11,32,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/053-test-typeswitch-extract/main.go
+++ b/refactoring/testdata/extractfunc/053-test-typeswitch-extract/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,9,2,18,2,newFunc,pass
+// <<<<<extract,9,2,18,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/053-test-typeswitch-extract/main.golden
+++ b/refactoring/testdata/extractfunc/053-test-typeswitch-extract/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,9,2,18,2,newFunc,pass
+// <<<<<extract,9,2,18,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/054-switch-extract/main.go
+++ b/refactoring/testdata/extractfunc/054-switch-extract/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,9,2,14,2,newFunc,pass
+// <<<<<extract,9,2,14,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/054-switch-extract/main.golden
+++ b/refactoring/testdata/extractfunc/054-switch-extract/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,9,2,14,2,newFunc,pass
+// <<<<<extract,9,2,14,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/055-switch-extract/main.go
+++ b/refactoring/testdata/extractfunc/055-switch-extract/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,8,1,19,2,newFunc,pass
+// <<<<<extract,8,1,19,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/055-switch-extract/main.golden
+++ b/refactoring/testdata/extractfunc/055-switch-extract/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,8,1,19,2,newFunc,pass
+// <<<<<extract,8,1,19,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/056-select-statement-extract/main.go
+++ b/refactoring/testdata/extractfunc/056-select-statement-extract/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,26,3,33,3,newFunc,pass
+// <<<<<extract,26,3,33,3,newFunc,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/056-select-statement-extract/main.golden
+++ b/refactoring/testdata/extractfunc/056-select-statement-extract/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,26,3,33,3,newFunc,pass
+// <<<<<extract,26,3,33,3,newFunc,pass
 package main
 
 import (

--- a/refactoring/testdata/extractfunc/057-select-statement-extract/main.go
+++ b/refactoring/testdata/extractfunc/057-select-statement-extract/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,18,2,23,2,newFunc,pass
+// <<<<<extract,18,2,23,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/057-select-statement-extract/main.golden
+++ b/refactoring/testdata/extractfunc/057-select-statement-extract/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,18,2,23,2,newFunc,pass
+// <<<<<extract,18,2,23,2,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/058-for-loop-extraction-initStatements-test/main.go
+++ b/refactoring/testdata/extractfunc/058-for-loop-extraction-initStatements-test/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,3,17,3,newFunction,pass
+// <<<<<extract,8,3,17,3,newFunction,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/058-for-loop-extraction-initStatements-test/main.golden
+++ b/refactoring/testdata/extractfunc/058-for-loop-extraction-initStatements-test/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,3,17,3,newFunction,pass
+// <<<<<extract,8,3,17,3,newFunction,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/059-extracting_pointer_expressions/main.go
+++ b/refactoring/testdata/extractfunc/059-extracting_pointer_expressions/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,10,2,10,13,Square,pass
+// <<<<<extract,10,2,10,13,Square,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/059-extracting_pointer_expressions/main.golden
+++ b/refactoring/testdata/extractfunc/059-extracting_pointer_expressions/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,10,2,10,13,Square,pass
+// <<<<<extract,10,2,10,13,Square,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/060-test001/main.go
+++ b/refactoring/testdata/extractfunc/060-test001/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,11,3,12,5,foo,pass
+// <<<<<extract,11,3,12,5,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/060-test001/main.golden
+++ b/refactoring/testdata/extractfunc/060-test001/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,11,3,12,5,foo,pass
+// <<<<<extract,11,3,12,5,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/061-test002-checkstart-positionlate/main.go
+++ b/refactoring/testdata/extractfunc/061-test002-checkstart-positionlate/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,4,11,33,foo,pass
+// <<<<<extract,9,4,11,33,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/061-test002-checkstart-positionlate/main.golden
+++ b/refactoring/testdata/extractfunc/061-test002-checkstart-positionlate/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,9,4,11,33,foo,pass
+// <<<<<extract,9,4,11,33,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/062-test003/main.go
+++ b/refactoring/testdata/extractfunc/062-test003/main.go
@@ -1,4 +1,4 @@
-//<<<<< extract,13,3,13,20,newFunc,pass
+// <<<<<extract,13,3,13,20,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/062-test003/main.golden
+++ b/refactoring/testdata/extractfunc/062-test003/main.golden
@@ -1,4 +1,4 @@
-//<<<<< extract,13,3,13,20,newFunc,pass
+// <<<<<extract,13,3,13,20,newFunc,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/064-test005/main.go
+++ b/refactoring/testdata/extractfunc/064-test005/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,12,19,foo,pass
+// <<<<<extract,12,2,12,19,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/064-test005/main.golden
+++ b/refactoring/testdata/extractfunc/064-test005/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,12,19,foo,pass
+// <<<<<extract,12,2,12,19,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/066-test007/main.go
+++ b/refactoring/testdata/extractfunc/066-test007/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,17,2,newFunction,fail
+// <<<<<extract,8,2,17,2,newFunction,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/066-test007/main.golden
+++ b/refactoring/testdata/extractfunc/066-test007/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,17,2,newFunction,fail
+// <<<<<extract,8,2,17,2,newFunction,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/068-test009/main.go
+++ b/refactoring/testdata/extractfunc/068-test009/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,15,4,15,10,Foo,fail
+// <<<<<extract,15,4,15,10,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/068-test009/main.golden
+++ b/refactoring/testdata/extractfunc/068-test009/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,15,4,15,10,Foo,fail
+// <<<<<extract,15,4,15,10,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/069-test010/main.go
+++ b/refactoring/testdata/extractfunc/069-test010/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,12,14,Foo,fail
+// <<<<<extract,12,2,12,14,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/069-test010/main.golden
+++ b/refactoring/testdata/extractfunc/069-test010/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,12,2,12,14,Foo,fail
+// <<<<<extract,12,2,12,14,Foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/070-test011/main.go
+++ b/refactoring/testdata/extractfunc/070-test011/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,FOO,pass
+// <<<<<extract,8,2,14,2,FOO,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/070-test011/main.golden
+++ b/refactoring/testdata/extractfunc/070-test011/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,FOO,pass
+// <<<<<extract,8,2,14,2,FOO,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/071-test012/main.go
+++ b/refactoring/testdata/extractfunc/071-test012/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,9,3,11,3,FOO,fail
+// <<<<<extract,9,3,11,3,FOO,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/071-test012/main.golden
+++ b/refactoring/testdata/extractfunc/071-test012/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,8,2,14,2,FOO,fail
+// <<<<<extract,8,2,14,2,FOO,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/072-test013/main.go
+++ b/refactoring/testdata/extractfunc/072-test013/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,11,3,13,3,FOO,fail
+// <<<<<extract,11,3,13,3,FOO,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/072-test013/main.golden
+++ b/refactoring/testdata/extractfunc/072-test013/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,11,3,13,3,FOO,fail
+// <<<<<extract,11,3,13,3,FOO,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/073-test014/main.go
+++ b/refactoring/testdata/extractfunc/073-test014/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,8,2,9,37,printB,pass
+// <<<<<extract,8,2,9,37,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/073-test014/main.golden
+++ b/refactoring/testdata/extractfunc/073-test014/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,8,2,9,37,printB,pass
+// <<<<<extract,8,2,9,37,printB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/074-test015/main.go
+++ b/refactoring/testdata/extractfunc/074-test015/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,10,3,12,4,FOO,pass
+// <<<<<extract,10,3,12,4,FOO,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/074-test015/main.golden
+++ b/refactoring/testdata/extractfunc/074-test015/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,10,3,12,4,FOO,pass
+// <<<<<extract,10,3,12,4,FOO,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/075-ctlflow-stmts/main.go
+++ b/refactoring/testdata/extractfunc/075-ctlflow-stmts/main.go
@@ -2,18 +2,18 @@ package main
 
 func main() {
 	for i := 1; i <= 10; i++ {
-		break //<<<<<extract,5,1,6,1,foo,fail
+		break // <<<<<extract,5,1,6,1,foo,fail
 	}
 	for i := 1; i <= 10; i++ {
-		continue //<<<<<extract,8,1,9,1,foo,fail
+		continue // <<<<<extract,8,1,9,1,foo,fail
 	}
 	goto lbl
-lbl: //<<<<<extract,11,1,12,11,foo,fail
-	n := 7 //<<<<<extract,12,6,12,11,foo,fail
+lbl: // <<<<<extract,11,1,12,11,foo,fail
+	n := 7 // <<<<<extract,12,6,12,11,foo,fail
 	for i := 1; i <= n; i++ {
 	}
 
-	defer foo() //<<<<<extract,16,2,16,12,bar,fail
+	defer foo() // <<<<<extract,16,2,16,12,bar,fail
 }
 
 func foo() {}

--- a/refactoring/testdata/extractfunc/076-struct-assign-member/main.go
+++ b/refactoring/testdata/extractfunc/076-struct-assign-member/main.go
@@ -7,6 +7,6 @@ func main() {
 		member int
 	}
 	s.member = 1
-	s.member = 3 //<<<<<extract,10,1,11,1,extracted,pass
+	s.member = 3 // <<<<<extract,10,1,11,1,extracted,pass
 	fmt.Println(s.member)
 }

--- a/refactoring/testdata/extractfunc/076-struct-assign-member/main.golden
+++ b/refactoring/testdata/extractfunc/076-struct-assign-member/main.golden
@@ -7,7 +7,7 @@ func main() {
 		member int
 	}
 	s.member = 1
-	s = extracted(s) //<<<<<extract,10,1,11,1,extracted,pass
+	s = extracted(s) // <<<<<extract,10,1,11,1,extracted,pass
 	fmt.Println(s.member)
 }
 

--- a/refactoring/testdata/extractfunc/077-structptr-assign-member/main.go
+++ b/refactoring/testdata/extractfunc/077-structptr-assign-member/main.go
@@ -6,6 +6,6 @@ func main() {
 	s := &struct {
 		member int
 	}{}
-	s.member = 3 //<<<<<extract,9,1,10,1,extracted,pass
+	s.member = 3 // <<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }

--- a/refactoring/testdata/extractfunc/077-structptr-assign-member/main.golden
+++ b/refactoring/testdata/extractfunc/077-structptr-assign-member/main.golden
@@ -6,7 +6,7 @@ func main() {
 	s := &struct {
 		member int
 	}{}
-	extracted(s) //<<<<<extract,9,1,10,1,extracted,pass
+	extracted(s) // <<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }
 

--- a/refactoring/testdata/extractfunc/078-structptr-assign-ptr/main.go
+++ b/refactoring/testdata/extractfunc/078-structptr-assign-ptr/main.go
@@ -6,6 +6,6 @@ func main() {
 	s := &struct {
 		member int
 	}{}
-	s = &struct{ member int }{4} //<<<<<extract,9,1,10,1,extracted,pass
+	s = &struct{ member int }{4} // <<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }

--- a/refactoring/testdata/extractfunc/078-structptr-assign-ptr/main.golden
+++ b/refactoring/testdata/extractfunc/078-structptr-assign-ptr/main.golden
@@ -6,7 +6,7 @@ func main() {
 	s := &struct {
 		member int
 	}{}
-	s = extracted() //<<<<<extract,9,1,10,1,extracted,pass
+	s = extracted() // <<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }
 

--- a/refactoring/testdata/extractfunc/079-issue42-1/main.go
+++ b/refactoring/testdata/extractfunc/079-issue42-1/main.go
@@ -19,7 +19,7 @@ func (dm Dummy) work(tmp string, listOfWork []string) (outputString string) {
 	inputString := tmp + " Suffix"
 	wrkDone := false
 	// This if can't seem to be extracted with any success
-	if !wrkDone && strings.Contains(inputString, "Suffix") { //<<<<<extract,22,2,24,2,extracted,pass
+	if !wrkDone && strings.Contains(inputString, "Suffix") { // <<<<<extract,22,2,24,2,extracted,pass
 		wrkDone = true
 	}
 	if wrkDone {

--- a/refactoring/testdata/extractfunc/079-issue42-1/main.golden
+++ b/refactoring/testdata/extractfunc/079-issue42-1/main.golden
@@ -29,7 +29,7 @@ func (dm Dummy) work(tmp string, listOfWork []string) (outputString string) {
 
 func (dm Dummy) extracted(inputString string) bool {
 	wrkDone := false
-	if !wrkDone && strings.Contains(inputString, "Suffix") { //<<<<<extract,22,2,24,2,extracted,pass
+	if !wrkDone && strings.Contains(inputString, "Suffix") { // <<<<<extract,22,2,24,2,extracted,pass
 		wrkDone = true
 	}
 	return wrkDone

--- a/refactoring/testdata/extractfunc/080-issue42-2/main.go
+++ b/refactoring/testdata/extractfunc/080-issue42-2/main.go
@@ -22,7 +22,7 @@ func main() {
 func (dm Dummy) work(listOfWork []string, inputString string) (string, bool) {
 	var workDone bool
 	// This for loop can't seem to be extracted with any success
-	for _, wrk := range listOfWork { //<<<<<extract,25,2,30,2,extracted,pass
+	for _, wrk := range listOfWork { // <<<<<extract,25,2,30,2,extracted,pass
 		for strings.Contains(inputString, wrk) {
 			inputString = strings.Replace(inputString, wrk, ".", -1)
 			workDone = true

--- a/refactoring/testdata/extractfunc/080-issue42-2/main.golden
+++ b/refactoring/testdata/extractfunc/080-issue42-2/main.golden
@@ -29,7 +29,7 @@ func (dm Dummy) work(listOfWork []string, inputString string) (string, bool) {
 
 func (dm Dummy) extracted(inputString string, listOfWork []string) (string, bool) {
 	var workDone bool
-	for _, wrk := range listOfWork { //<<<<<extract,25,2,30,2,extracted,pass
+	for _, wrk := range listOfWork { // <<<<<extract,25,2,30,2,extracted,pass
 		for strings.Contains(inputString, wrk) {
 			inputString = strings.Replace(inputString, wrk, ".", -1)
 			workDone = true

--- a/refactoring/testdata/extractfunc/081-local-init-leftovers/main.go
+++ b/refactoring/testdata/extractfunc/081-local-init-leftovers/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,38,changeB,fail
+// <<<<<extract,9,2,11,38,changeB,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/082-local-init/main.go
+++ b/refactoring/testdata/extractfunc/082-local-init/main.go
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,38,changeB,pass
+// <<<<<extract,9,2,11,38,changeB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/082-local-init/main.golden
+++ b/refactoring/testdata/extractfunc/082-local-init/main.golden
@@ -1,4 +1,4 @@
-// <<<<< extract,9,2,11,38,changeB,pass
+// <<<<<extract,9,2,11,38,changeB,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/083-issue43-1/main.go
+++ b/refactoring/testdata/extractfunc/083-issue43-1/main.go
@@ -10,7 +10,7 @@ func main() {
 	missingSuffix := true
 	// If you extract this if
 	// then it ignores the current value of missingSuffix
-	// <<<<< extract,14,2,16,2,check,pass
+	// <<<<<extract,14,2,16,2,check,pass
 	if strings.Contains(inputString, "Suffix") {
 		missingSuffix = false
 	}

--- a/refactoring/testdata/extractfunc/083-issue43-1/main.golden
+++ b/refactoring/testdata/extractfunc/083-issue43-1/main.golden
@@ -10,7 +10,7 @@ func main() {
 	missingSuffix := true
 	// If you extract this if
 	// then it ignores the current value of missingSuffix
-	// <<<<< extract,14,2,16,2,check,pass
+	// <<<<<extract,14,2,16,2,check,pass
 	missingSuffix = check(inputString)
 
 	fmt.Print("string:", inputString)

--- a/refactoring/testdata/extractfunc/084-issue43-2/main.go
+++ b/refactoring/testdata/extractfunc/084-issue43-2/main.go
@@ -10,7 +10,7 @@ func main() {
 	missingSuffix := true
 	// If you extract this if
 	// then it ignores the current value of missingSuffix
-	// <<<<< extract,14,2,16,2,check,pass
+	// <<<<<extract,14,2,16,2,check,pass
 	if strings.Contains(inputString, "Suffix") {
 		missingSuffix = false
 	}

--- a/refactoring/testdata/extractfunc/084-issue43-2/main.golden
+++ b/refactoring/testdata/extractfunc/084-issue43-2/main.golden
@@ -10,7 +10,7 @@ func main() {
 	missingSuffix := true
 	// If you extract this if
 	// then it ignores the current value of missingSuffix
-	// <<<<< extract,14,2,16,2,check,pass
+	// <<<<<extract,14,2,16,2,check,pass
 	missingSuffix = check()
 
 	fmt.Print("string:", inputString)

--- a/refactoring/testdata/extractfunc/085-issue43-3/main.go
+++ b/refactoring/testdata/extractfunc/085-issue43-3/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	inputString := "bob" + ""
 	hasSuffix := false
-	// <<<<< extract,12,2,14,2,check,pass
+	// <<<<<extract,12,2,14,2,check,pass
 	if strings.Contains(inputString, "Suffix") {
 		hasSuffix = true
 	}

--- a/refactoring/testdata/extractfunc/085-issue43-3/main.golden
+++ b/refactoring/testdata/extractfunc/085-issue43-3/main.golden
@@ -8,7 +8,7 @@ import (
 func main() {
 	inputString := "bob" + ""
 	hasSuffix := false
-	// <<<<< extract,12,2,14,2,check,pass
+	// <<<<<extract,12,2,14,2,check,pass
 	hasSuffix = check(inputString)
 
 	fmt.Print("string:", inputString)

--- a/refactoring/testdata/extractfunc/086-issue43-4/main.go
+++ b/refactoring/testdata/extractfunc/086-issue43-4/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	inputString := "bob" + ""
 	var hasSuffix bool
-	// <<<<< extract,12,2,14,2,check,pass
+	// <<<<<extract,12,2,14,2,check,pass
 	if strings.Contains(inputString, "Suffix") {
 		hasSuffix = true
 	}

--- a/refactoring/testdata/extractfunc/086-issue43-4/main.golden
+++ b/refactoring/testdata/extractfunc/086-issue43-4/main.golden
@@ -8,7 +8,7 @@ import (
 func main() {
 	inputString := "bob" + ""
 	var hasSuffix bool
-	// <<<<< extract,12,2,14,2,check,pass
+	// <<<<<extract,12,2,14,2,check,pass
 	hasSuffix = check(inputString)
 
 	fmt.Print("string:", inputString)

--- a/refactoring/testdata/extractfunc/087-local-loop-leftovers/main.go
+++ b/refactoring/testdata/extractfunc/087-local-loop-leftovers/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,25,2,foo,fail
+// <<<<<extract,20,2,25,2,foo,fail
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/088-local-loop/main.go
+++ b/refactoring/testdata/extractfunc/088-local-loop/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,25,2,foo,pass
+// <<<<<extract,20,2,25,2,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/088-local-loop/main.golden
+++ b/refactoring/testdata/extractfunc/088-local-loop/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,20,2,25,2,foo,pass
+// <<<<<extract,20,2,25,2,foo,pass
 package main
 
 import "fmt"

--- a/refactoring/testdata/extractfunc/089-local-assign-member/main.go
+++ b/refactoring/testdata/extractfunc/089-local-assign-member/main.go
@@ -6,6 +6,6 @@ func main() {
 	var s struct {
 		member int
 	}
-	s.member = 3 //<<<<<extract,9,1,10,1,extracted,pass
+	s.member = 3 // <<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }

--- a/refactoring/testdata/extractfunc/089-local-assign-member/main.golden
+++ b/refactoring/testdata/extractfunc/089-local-assign-member/main.golden
@@ -6,7 +6,7 @@ func main() {
 	var s struct {
 		member int
 	}
-	s = extracted() //<<<<<extract,9,1,10,1,extracted,pass
+	s = extracted() // <<<<<extract,9,1,10,1,extracted,pass
 	fmt.Println(s.member)
 }
 

--- a/refactoring/testdata/extractfunc/090-using-named-return/main.go
+++ b/refactoring/testdata/extractfunc/090-using-named-return/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,115,2,122,2,test_func,pass
+// <<<<<extract,115,2,122,2,test_func,pass
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/refactoring/testdata/extractfunc/090-using-named-return/main.golden
+++ b/refactoring/testdata/extractfunc/090-using-named-return/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,115,2,122,2,test_func,pass
+// <<<<<extract,115,2,122,2,test_func,pass
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/refactoring/testdata/extractfunc/091-used-named-return/main.go
+++ b/refactoring/testdata/extractfunc/091-used-named-return/main.go
@@ -1,4 +1,4 @@
-//<<<<<extract,115,2,124,2,test_func,pass
+// <<<<<extract,115,2,124,2,test_func,pass
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/refactoring/testdata/extractfunc/091-used-named-return/main.golden
+++ b/refactoring/testdata/extractfunc/091-used-named-return/main.golden
@@ -1,4 +1,4 @@
-//<<<<<extract,115,2,124,2,test_func,pass
+// <<<<<extract,115,2,124,2,test_func,pass
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/refactoring/testdata/godoc/012-multiple-types/main.golden
+++ b/refactoring/testdata/godoc/012-multiple-types/main.golden
@@ -1,6 +1,6 @@
 package main // <<<<< godoc,1,1,1,1,pass
 
-//  TODO: NEEDS COMMENT INFO
+// TODO: NEEDS COMMENT INFO
 type (
 	a int
 	B int

--- a/refactoring/testdata/godoc/013-multiple-same-line/main.golden
+++ b/refactoring/testdata/godoc/013-multiple-same-line/main.golden
@@ -1,6 +1,6 @@
 package main // <<<<< godoc,1,1,1,1,pass
 
-//  TODO: NEEDS COMMENT INFO
+// TODO: NEEDS COMMENT INFO
 type (
 	a int
 	B int

--- a/refactoring/testdata/godoc/014-consistent-comment-style/main.golden
+++ b/refactoring/testdata/godoc/014-consistent-comment-style/main.golden
@@ -15,7 +15,7 @@ const (
 	StatusBad = 2
 )
 
-//  TODO: NEEDS COMMENT INFO
+// TODO: NEEDS COMMENT INFO
 var (
 	Foo = "Foo"
 	Bar = "Bar"


### PR DESCRIPTION
see #60

updating go to 1.20 broke tests mostly over spacing in the comments. fixes dataflow tests. fixes refactoring tests except the broken cgo one still. 

the cli tests are giving me a headache. i seem able to run the tool doing refactoring from stdin via vim plugin I think but the tests are stdin and not happy, it's an easy fix to make a little test file but I want to nail down that the cli works on files and stdin still, hope to take care of that soon. 