### PR TITLE
Copy existing environment when loading packages

### DIFF
--- a/refactoring/refactoring.go
+++ b/refactoring/refactoring.go
@@ -313,7 +313,7 @@ func (r *RefactoringBase) Init(config *Config, desc *Description) *Result {
 func createLoader(config *Config, errorHandler func(error)) (*loader.Program, error) {
 	// TODO: need to rehack most of this probably to go away as now modules
 	// do not require this GOPATH hackery, it may "just work" in PWD as is
-	var env []string
+	env := os.Environ()
 	if config.GoPath != "" {
 		env = append(env, "GOPATH="+config.GoPath)
 	} else if gopath := os.Getenv("GOPATH"); gopath != "" {


### PR DESCRIPTION
Sometimes you might be running in an environment with a limited user setup and then tests fail with:
```
    testutil.go:226: Scope is /builddir/build/BUILD/godoctor-0.7/_build/src/github.com/godoctor/godoctor/refactoring/testdata/debug/fmt-1/main.go
        Error: err: exit status 1: stderr: build cache is required, but could not be located: GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are defined
```
If you set `GOCACHE` in the environment, then things still don't work because `createLoader` sets up a completely empty `Environ`, so change it to copy the existing environment.