### PR TITLE
Fix some non-constant format strings

### DIFF
--- a/refactoring/debug.go
+++ b/refactoring/debug.go
@@ -222,7 +222,7 @@ func (r *Debug) showAffected(out io.Writer) {
 		}
 		sort.Strings(result)
 		for _, line := range result {
-			fmt.Fprintf(out, line)
+			fmt.Fprint(out, line)
 		}
 	default:
 		r.Log.Error(errorMsg)

--- a/refactoring/refactoring.go
+++ b/refactoring/refactoring.go
@@ -227,7 +227,7 @@ func (r *RefactoringBase) Init(config *Config, desc *Description) *Result {
 	if config.Scope == nil {
 		var msg string
 		config.Scope, msg = r.guessScope(config)
-		r.Log.Infof(msg)
+		r.Log.Info(msg)
 	} else {
 		r.Log.Infof("Scope is %s", strings.Join(config.Scope, " "))
 	}
@@ -667,7 +667,7 @@ func (r *RefactoringBase) UpdateLog(config *Config, checkForErrors bool) {
 				oldPos := oldFile.Pos(extent.Offset)
 				newPos := mapPos(r.Program.Fset, oldPos,
 					r.Edits, newProgFiles, false)
-				r.Log.Infof(describeEdit(extent, replace))
+				r.Log.Info(describeEdit(extent, replace))
 				r.Log.AssociatePos(newPos, newPos)
 				return true
 			})


### PR DESCRIPTION
Go 1.24 tests now run vet checks for this [1] and are failing because of it.

[1] https://go.dev/doc/go1.24#vet